### PR TITLE
Update web-ext dependency to exclude 7.0.0 and above

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "parcel": "^2.0.0",
-    "web-ext": "^6.4.0"
+    "web-ext": "^6.4.0 <7.0.0"
   },
   "dependencies": {
     "@parcel/plugin": "^2.0.0"


### PR DESCRIPTION
web-ext 7.0.0 contains a breaking change: it migrated the library to use ES modules, and since this library directly require web-ext, it either needs to also be converted to use Modules or to use dynamic `import`, neither of which is trivial.

    Error [ERR_REQUIRE_ESM]: require() of ES Module node_modules/web-ext/index.js from node_modules/parcel-reporter-web-ext/src/index.js not supported.
    Instead change the require of node_modules/web-ext/index.js in parcel-reporter-web-ext/src/index.js to a dynamic import() which is available in all CommonJS modules.
        at NodePackageManager.load (node_modules/@parcel/package-manager/lib/index.js:3375:15)
        at NodePackageManager.requireSync (node_modules/@parcel/package-manager/lib/index.js:3353:21)
        at m.require (node_modules/@parcel/package-manager/lib/index.js:3366:25)
        at require (node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
        at Object.<anonymous> (node_modules/parcel-reporter-web-ext/src/index.js:1:78)
        at Module._compile (node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
        at NodePackageManager.load (node_modules/@parcel/package-manager/lib/index.js:3375:15)
        at NodePackageManager.require (node_modules/@parcel/package-manager/lib/index.js:3349:21)
        at async loadPlugin (node_modules/@parcel/core/lib/loadParcelPlugin.js:185:16) {
      code: 'ERR_REQUIRE_ESM'
    }

Short of a fix, the best option is to fix the version constraint to ensure that this library declares it is not compatible with web-ext 7.0.0 and above.